### PR TITLE
Add 404 page and improve GitHub Pages routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <script>
+      // Check if we have a redirected path from 404.html
+      (function() {
+        const originalPath = localStorage.getItem('originalPath');
+        if (originalPath) {
+          localStorage.removeItem('originalPath');
+          // If there was a saved path, navigate to it
+          const base = window.location.pathname.replace(/\/$/, '');
+          window.history.replaceState(null, null, `${base}/${originalPath}`);
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Redirecting...</title>
+  <script>
+    // Single Page App redirect script for GitHub Pages
+    // This handles direct navigation to routes when deployed on GitHub Pages
+    (function() {
+      // Parse the URL path
+      const path = window.location.pathname;
+      const pathSegmentsToKeep = 1; // Keep the repository name in path
+
+      // Get repository name from path
+      // This won't work if navigating to domain root, but that's fine for GitHub Pages
+      const repo = path.split('/')[1];
+      localStorage.setItem('originalPath', path.split('/').slice(pathSegmentsToKeep + 1).join('/'));
+      
+      // Redirect to index with original path preserved
+      window.location.href = `/${repo}/`;
+    })();
+  </script>
+</head>
+<body>
+  <p>Redirecting...</p>
+</body>
+</html>

--- a/src/components/NotFound.vue
+++ b/src/components/NotFound.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="not-found">
+    <div class="error-container">
+      <div class="error-code">404</div>
+      <h1>Page Not Found</h1>
+      <p>The page you are looking for doesn't exist or has been moved.</p>
+      <div class="actions">
+        <router-link to="/weather" class="home-link">Go to Weather Dashboard</router-link>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'NotFound'
+}
+</script>
+
+<style scoped>
+.not-found {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 70vh;
+}
+
+.error-container {
+  background: white;
+  padding: 3rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  max-width: 500px;
+}
+
+.error-code {
+  font-size: 8rem;
+  font-weight: 700;
+  color: #1976d2;
+  line-height: 1;
+  margin-bottom: 1rem;
+  opacity: 0.7;
+}
+
+h1 {
+  color: #0d47a1;
+  margin-bottom: 1rem;
+}
+
+p {
+  color: #455a64;
+  margin-bottom: 2rem;
+}
+
+.actions {
+  margin-top: 2rem;
+}
+
+.home-link {
+  display: inline-block;
+  background-color: #1976d2;
+  color: white;
+  padding: 0.8rem 1.5rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.home-link:hover {
+  background-color: #1565c0;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import App from './App.vue'
 import WeatherDashboard from './components/WeatherDashboard.vue'
 import ForecastView from './components/ForecastView.vue'
 import LocationSearch from './components/LocationSearch.vue'
+import NotFound from './components/NotFound.vue'
 
 // Get the base URL from Vite
 const base = import.meta.env.BASE_URL || '/'
@@ -12,7 +13,9 @@ const routes = [
   { path: '/', redirect: '/weather' },
   { path: '/weather', component: WeatherDashboard },
   { path: '/forecast', component: ForecastView },
-  { path: '/search', component: LocationSearch }
+  { path: '/search', component: LocationSearch },
+  // 404 route - must be last!
+  { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFound }
 ]
 
 const router = createRouter({


### PR DESCRIPTION
This PR adds a 404 page and improves client-side routing for GitHub Pages as specified in issue #6.

## Changes made:

1. **404 Not Found Component**
   - Created a new `NotFound.vue` component with a clear error message
   - Added styling for the 404 page with a large error code display

2. **Vue Router Configuration**
   - Added a catch-all route in the Vue Router setup to handle any undefined routes
   - The catch-all route directs users to the custom 404 page

3. **GitHub Pages Routing Solution**
   - Added a `public/404.html` file that handles the GitHub Pages 404 redirects
   - Implemented path preservation using localStorage
   - Updated `index.html` to restore the original path after redirection

## How to test:
1. Build and deploy the application
2. Try accessing a non-existent route directly (e.g., `/this-route-does-not-exist`)
3. Verify that you are properly redirected and see the 404 page
4. Try navigating to actual routes directly (e.g., `/forecast`) and verify they load correctly

These changes ensure that users can navigate directly to any route without errors and receive a helpful message for non-existent routes.

Resolves #6