### PR TITLE
Fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,15 +24,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -62,10 +62,10 @@ jobs:
           VITE_WEATHER_API_KEY: ${{ secrets.VITE_WEATHER_API_KEY }}
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR updates the GitHub Actions workflow with the latest action versions:

- Update actions/checkout from v3 to v4
- Update actions/setup-node from v3 to v4
- Update Node.js from 16 to 18
- Update actions/configure-pages from v3 to v4
- Update actions/upload-pages-artifact from v2 to v3
- Update actions/deploy-pages from v2 to v4

These updates should fix the workflow issues and ensure compatibility with the latest GitHub Actions environment.