### PR TITLE
Feature: New dashboard with multiple cities

### DIFF
--- a/src/components/CitiesOverview.vue
+++ b/src/components/CitiesOverview.vue
@@ -1,0 +1,298 @@
+<template>
+  <div class="cities-overview">
+    <div class="header">
+      <h2>Japan Weather Overview</h2>
+      <p>{{ currentDate }}</p>
+    </div>
+    <div class="cities-grid">
+      <div 
+        v-for="city in cities" 
+        :key="city.name" 
+        class="city-card"
+        @click="goToCity(city)"
+      >
+        <div v-if="loading" class="city-loading">
+          <p>Loading...</p>
+        </div>
+        <div v-else class="city-content">
+          <h3>{{ city.name }}</h3>
+          <div class="weather-summary">
+            <div class="temp">{{ Math.round(city.weather.temp) }}°C</div>
+            <div class="icon">
+              <img :src="`http://openweathermap.org/img/wn/${city.weather.icon}@2x.png`" :alt="city.weather.description" />
+            </div>
+          </div>
+          <p class="weather-desc">{{ city.weather.description }}</p>
+          <div class="city-details">
+            <div class="detail">
+              <span class="label">Humidity</span>
+              <span class="value">{{ city.weather.humidity }}%</span>
+            </div>
+            <div class="detail">
+              <span class="label">Wind</span>
+              <span class="value">{{ city.weather.wind }} m/s</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="refresh-controls">
+      <button @click="refreshAll" class="refresh-btn">
+        Refresh All
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { format } from 'date-fns';
+
+interface CityWeather {
+  temp: number;
+  description: string;
+  icon: string;
+  humidity: number;
+  wind: number;
+}
+
+interface City {
+  name: string;
+  lat: number;
+  lon: number;
+  weather: CityWeather;
+}
+
+export default defineComponent({
+  name: 'CitiesOverview',
+  setup() {
+    const router = useRouter();
+    const cities = ref<City[]>([
+      {
+        name: 'Tokyo',
+        lat: 35.6895,
+        lon: 139.6917,
+        weather: { temp: 0, description: '', icon: '', humidity: 0, wind: 0 }
+      },
+      {
+        name: 'Kyoto',
+        lat: 35.0116,
+        lon: 135.7681,
+        weather: { temp: 0, description: '', icon: '', humidity: 0, wind: 0 }
+      },
+      {
+        name: 'Sapporo',
+        lat: 43.0618,
+        lon: 141.3545,
+        weather: { temp: 0, description: '', icon: '', humidity: 0, wind: 0 }
+      },
+      {
+        name: 'Okinawa',
+        lat: 26.2124,
+        lon: 127.6809,
+        weather: { temp: 0, description: '', icon: '', humidity: 0, wind: 0 }
+      }
+    ]);
+    const loading = ref<boolean>(true);
+    const currentDate = ref<string>(format(new Date(), 'EEEE, MMMM d, yyyy'));
+
+    const goToCity = (city: City): void => {
+      router.push({ 
+        name: 'CityView',
+        params: { city: city.name.toLowerCase() },
+        state: { city }
+      });
+    };
+
+    const fetchWeatherForAllCities = async (): Promise<void> => {
+      loading.value = true;
+      
+      // Simulate API call with delay
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      
+      // Update with simulated weather data
+      cities.value = cities.value.map(city => {
+        return {
+          ...city,
+          weather: generateWeatherForCity(city.name)
+        };
+      });
+      
+      loading.value = false;
+    };
+    
+    const generateWeatherForCity = (cityName: string): CityWeather => {
+      // Simulate different temperature ranges for different cities
+      const baseTempMap: Record<string, number> = {
+        'Tokyo': 18,
+        'Kyoto': 17,
+        'Sapporo': 10,
+        'Okinawa': 26
+      };
+      
+      const baseTemp = baseTempMap[cityName] || 20;
+      const weatherTypes = ['Clear', 'Clouds', 'Rain', 'Drizzle', 'Thunderstorm'];
+      const descriptions = [
+        'clear sky', 'few clouds', 'scattered clouds', 
+        'broken clouds', 'light rain', 'moderate rain'
+      ];
+      const icons = ['01d', '02d', '03d', '04d', '09d', '10d'];
+      
+      return {
+        temp: baseTemp + (Math.random() * 6 - 3),
+        description: descriptions[Math.floor(Math.random() * descriptions.length)],
+        icon: icons[Math.floor(Math.random() * icons.length)],
+        humidity: Math.floor(Math.random() * 30) + 50,
+        wind: Math.floor(Math.random() * 7) + 1
+      };
+    };
+
+    const refreshAll = (): void => {
+      fetchWeatherForAllCities();
+    };
+
+    onMounted(() => {
+      fetchWeatherForAllCities();
+    });
+
+    return {
+      cities,
+      loading,
+      currentDate,
+      goToCity,
+      refreshAll
+    };
+  }
+});
+</script>
+
+<style scoped>
+.cities-overview {
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 2rem;
+}
+
+.header {
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.header h2 {
+  font-size: 2rem;
+  color: #0d47a1;
+  margin-bottom: 0.5rem;
+}
+
+.header p {
+  color: #757575;
+  font-size: 0.9rem;
+}
+
+.cities-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
+.city-card {
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  padding: 1.5rem;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.city-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+}
+
+.city-loading {
+  text-align: center;
+  padding: 2rem;
+  color: #757575;
+}
+
+.city-content h3 {
+  font-size: 1.5rem;
+  color: #1565c0;
+  margin-bottom: 1rem;
+}
+
+.weather-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.temp {
+  font-size: 2.5rem;
+  font-weight: 300;
+  color: #0d47a1;
+}
+
+.icon img {
+  width: 70px;
+  height: 70px;
+}
+
+.weather-desc {
+  text-transform: capitalize;
+  color: #455a64;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.city-details {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1rem;
+}
+
+.detail {
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-size: 0.8rem;
+  color: #757575;
+  margin-bottom: 0.25rem;
+}
+
+.value {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: #455a64;
+}
+
+.refresh-controls {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.refresh-btn {
+  background-color: #1976d2;
+  color: white;
+  border: none;
+  padding: 0.8rem 1.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.2s;
+}
+
+.refresh-btn:hover {
+  background-color: #1565c0;
+}
+
+@media (max-width: 768px) {
+  .cities-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/components/CityDashboard.vue
+++ b/src/components/CityDashboard.vue
@@ -1,0 +1,421 @@
+<template>
+  <div class="city-dashboard">
+    <div class="city-controls">
+      <div class="city-display">
+        <h2>{{ city.name }}</h2>
+        <p>{{ currentDate }}</p>
+      </div>
+      <div class="actions">
+        <button @click="refreshWeather" class="refresh-btn">
+          Refresh
+        </button>
+        <router-link to="/" class="back-link">Back to Dashboard</router-link>
+      </div>
+    </div>
+
+    <div v-if="loading" class="loading">
+      <p>Loading weather data...</p>
+    </div>
+
+    <div v-else-if="error" class="error">
+      <p>{{ error }}</p>
+      <button @click="refreshWeather">Try Again</button>
+    </div>
+
+    <div v-else>
+      <div class="current-weather">
+        <div class="temperature">
+          <span class="temp-value">{{ Math.round(weather.main.temp) }}°</span>
+          <span class="temp-unit">C</span>
+        </div>
+        <div class="weather-info">
+          <img :src="`http://openweathermap.org/img/wn/${weather.weather[0].icon}@2x.png`" :alt="weather.weather[0].description" class="weather-icon" />
+          <p class="weather-description">{{ weather.weather[0].description }}</p>
+        </div>
+      </div>
+
+      <div class="weather-details">
+        <div class="detail-item">
+          <span class="detail-label">Feels Like</span>
+          <span class="detail-value">{{ Math.round(weather.main.feels_like) }}°C</span>
+        </div>
+        <div class="detail-item">
+          <span class="detail-label">Humidity</span>
+          <span class="detail-value">{{ weather.main.humidity }}%</span>
+        </div>
+        <div class="detail-item">
+          <span class="detail-label">Wind</span>
+          <span class="detail-value">{{ Math.round(weather.wind.speed) }} m/s</span>
+        </div>
+        <div class="detail-item">
+          <span class="detail-label">Pressure</span>
+          <span class="detail-value">{{ weather.main.pressure }} hPa</span>
+        </div>
+      </div>
+
+      <h3 class="forecast-title">5-Day Forecast</h3>
+      <div class="forecast-container">
+        <div v-for="(day, index) in forecast" :key="index" class="forecast-day">
+          <p class="forecast-date">{{ day.date }}</p>
+          <img :src="`http://openweathermap.org/img/wn/${day.icon}.png`" :alt="day.description" class="forecast-icon" />
+          <p class="forecast-temp">{{ Math.round(day.temp) }}°C</p>
+          <p class="forecast-desc">{{ day.description }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted, PropType } from 'vue';
+import { format } from 'date-fns';
+import { WeatherData } from '@/types';
+
+interface City {
+  name: string;
+  lat: number;
+  lon: number;
+}
+
+interface ForecastDay {
+  date: string;
+  temp: number;
+  description: string;
+  icon: string;
+}
+
+export default defineComponent({
+  name: 'CityDashboard',
+  props: {
+    city: {
+      type: Object as PropType<City>,
+      required: true
+    }
+  },
+  setup(props) {
+    const weather = ref<WeatherData | null>(null);
+    const forecast = ref<ForecastDay[]>([]);
+    const loading = ref<boolean>(true);
+    const error = ref<string | null>(null);
+    const currentDate = ref<string>(format(new Date(), 'EEEE, MMMM d, yyyy'));
+    
+    const fetchWeather = async (): Promise<void> => {
+      try {
+        loading.value = true;
+        error.value = null;
+        
+        // Simulate API call with delay
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        
+        // Sample weather data for the selected city
+        weather.value = {
+          main: {
+            temp: getRandomTemp(props.city.name),
+            feels_like: getRandomTemp(props.city.name) - 1,
+            humidity: Math.floor(Math.random() * 30) + 50,
+            pressure: Math.floor(Math.random() * 20) + 1000
+          },
+          weather: [
+            {
+              main: getRandomWeatherType(),
+              description: getRandomWeatherDescription(),
+              icon: getRandomWeatherIcon()
+            }
+          ],
+          wind: {
+            speed: Math.floor(Math.random() * 7) + 1
+          },
+          name: props.city.name
+        };
+        
+        // Sample 5-day forecast
+        forecast.value = generateForecast();
+        
+        loading.value = false;
+      } catch (err) {
+        console.error('Error fetching weather:', err);
+        error.value = 'Failed to load weather data. Please try again.';
+        loading.value = false;
+      }
+    };
+
+    const getRandomTemp = (cityName: string): number => {
+      // Simulate different temperature ranges for different cities
+      const baseTempMap: Record<string, number> = {
+        'Tokyo': 18,
+        'Kyoto': 17,
+        'Sapporo': 10,
+        'Okinawa': 26
+      };
+      
+      const baseTemp = baseTempMap[cityName] || 20;
+      return baseTemp + (Math.random() * 6 - 3);
+    };
+    
+    const getRandomWeatherType = (): string => {
+      const types = ['Clear', 'Clouds', 'Rain', 'Drizzle', 'Thunderstorm'];
+      return types[Math.floor(Math.random() * types.length)];
+    };
+    
+    const getRandomWeatherDescription = (): string => {
+      const descriptions = [
+        'clear sky', 'few clouds', 'scattered clouds', 
+        'broken clouds', 'light rain', 'moderate rain',
+        'light drizzle', 'thunderstorm'
+      ];
+      return descriptions[Math.floor(Math.random() * descriptions.length)];
+    };
+    
+    const getRandomWeatherIcon = (): string => {
+      const icons = ['01d', '02d', '03d', '04d', '09d', '10d', '11d', '13d'];
+      return icons[Math.floor(Math.random() * icons.length)];
+    };
+    
+    const generateForecast = (): ForecastDay[] => {
+      const result: ForecastDay[] = [];
+      const today = new Date();
+      
+      for (let i = 1; i <= 5; i++) {
+        const date = new Date();
+        date.setDate(today.getDate() + i);
+        
+        result.push({
+          date: format(date, 'EEE, MMM d'),
+          temp: getRandomTemp(props.city.name) + (Math.random() * 4 - 2),
+          description: getRandomWeatherDescription(),
+          icon: getRandomWeatherIcon()
+        });
+      }
+      
+      return result;
+    };
+
+    const refreshWeather = (): void => {
+      fetchWeather();
+    };
+
+    onMounted(() => {
+      fetchWeather();
+    });
+
+    return {
+      weather,
+      forecast,
+      loading,
+      error,
+      currentDate,
+      refreshWeather
+    };
+  }
+});
+</script>
+
+<style scoped>
+.city-dashboard {
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 2rem;
+}
+
+.city-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.city-display h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: #1565c0;
+}
+
+.city-display p {
+  color: #757575;
+  font-size: 0.9rem;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.refresh-btn {
+  background-color: #1976d2;
+  color: white;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
+}
+
+.refresh-btn:hover {
+  background-color: #1565c0;
+}
+
+.back-link {
+  color: #1976d2;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.loading, .error {
+  text-align: center;
+  padding: 2rem;
+  color: #757575;
+}
+
+.error button {
+  background-color: #ef5350;
+  color: white;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 1rem;
+}
+
+.current-weather {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+.temperature {
+  display: flex;
+  align-items: flex-start;
+}
+
+.temp-value {
+  font-size: 5rem;
+  font-weight: 300;
+  line-height: 1;
+  color: #0d47a1;
+}
+
+.temp-unit {
+  font-size: 2rem;
+  color: #0d47a1;
+  margin-top: 0.5rem;
+}
+
+.weather-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.weather-icon {
+  width: 80px;
+  height: 80px;
+}
+
+.weather-description {
+  text-transform: capitalize;
+  color: #455a64;
+}
+
+.weather-details {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-label {
+  font-size: 0.85rem;
+  color: #757575;
+  margin-bottom: 0.25rem;
+}
+
+.detail-value {
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: #455a64;
+}
+
+.forecast-title {
+  margin-bottom: 1rem;
+  color: #1565c0;
+  font-size: 1.5rem;
+}
+
+.forecast-container {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1rem;
+}
+
+.forecast-day {
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.forecast-date {
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  color: #455a64;
+}
+
+.forecast-icon {
+  width: 50px;
+  height: 50px;
+  margin: 0 auto;
+}
+
+.forecast-temp {
+  font-size: 1.2rem;
+  font-weight: 500;
+  margin: 0.5rem 0;
+  color: #1565c0;
+}
+
+.forecast-desc {
+  font-size: 0.8rem;
+  color: #757575;
+  text-transform: capitalize;
+}
+
+@media (max-width: 768px) {
+  .city-controls {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .current-weather {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .weather-details {
+    grid-template-columns: 1fr;
+  }
+  
+  .forecast-container {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,13 +5,25 @@ import WeatherDashboard from './components/WeatherDashboard.vue'
 import ForecastView from './components/ForecastView.vue'
 import LocationSearch from './components/LocationSearch.vue'
 import NotFound from './components/NotFound.vue'
+import CitiesOverview from './components/CitiesOverview.vue'
+import CityDashboard from './components/CityDashboard.vue'
 
 // Get the base URL from Vite
 const base = import.meta.env.BASE_URL || '/'
 
 const routes: RouteRecordRaw[] = [
-  { path: '/', redirect: '/weather' },
-  { path: '/weather', component: WeatherDashboard },
+  { path: '/', component: CitiesOverview },
+  { path: '/weather', redirect: '/' },
+  { path: '/city/:city', name: 'CityView', component: CityDashboard, props: (route) => {
+    const cities = {
+      tokyo: { name: 'Tokyo', lat: 35.6895, lon: 139.6917 },
+      kyoto: { name: 'Kyoto', lat: 35.0116, lon: 135.7681 },
+      sapporo: { name: 'Sapporo', lat: 43.0618, lon: 141.3545 },
+      okinawa: { name: 'Okinawa', lat: 26.2124, lon: 127.6809 }
+    };
+    const cityName = route.params.city as string;
+    return { city: cities[cityName as keyof typeof cities] || cities.tokyo };
+  }},
   { path: '/forecast', component: ForecastView },
   { path: '/search', component: LocationSearch },
   // 404 route - must be last!


### PR DESCRIPTION
This PR implements the new dashboard requested in Issue #19:

- Added a main dashboard displaying weather for Tokyo, Kyoto, Sapporo, and Okinawa
- Created a new city-specific page that shows both current weather and 5-day forecast
- Updated router configuration to support the new views
- Added TypeScript interfaces for all components

The new dashboard allows users to see an overview of major Japanese cities and click on any city to view detailed weather information and forecasts for that location.