### PR TITLE
Add cities dashboard with 5-day forecast

### DIFF
--- a/src/components/CitiesDashboard.vue
+++ b/src/components/CitiesDashboard.vue
@@ -1,0 +1,358 @@
+<template>
+  <div class="cities-dashboard">
+    <h2 class="dashboard-title">Japan Cities Weather</h2>
+    
+    <div class="city-cards">
+      <div v-for="city in cities" :key="city.id" class="city-card" @click="goToCityForecast(city.id)">
+        <div class="city-header">
+          <h3>{{ city.name }}</h3>
+          <span v-if="city.weather" class="timestamp">Updated: {{ formatTime() }}</span>
+        </div>
+        
+        <div v-if="loadingStates[city.id]" class="city-loading">
+          <p>Loading weather data...</p>
+        </div>
+        
+        <div v-else-if="errorStates[city.id]" class="city-error">
+          <p>{{ errorStates[city.id] }}</p>
+          <button @click.stop="fetchCityWeather(city)">Retry</button>
+        </div>
+        
+        <div v-else-if="city.weather" class="city-content">
+          <div class="temperature">
+            <span class="temp-value">{{ Math.round(city.weather.main.temp) }}°C</span>
+          </div>
+          <div class="weather-info">
+            <img 
+              :src="`http://openweathermap.org/img/wn/${city.weather.weather[0].icon}@2x.png`" 
+              :alt="city.weather.weather[0].description" 
+              class="weather-icon" 
+            />
+            <p class="weather-description">{{ city.weather.weather[0].description }}</p>
+          </div>
+          <div class="city-details">
+            <div class="detail-item">
+              <span class="detail-label">Humidity</span>
+              <span class="detail-value">{{ city.weather.main.humidity }}%</span>
+            </div>
+            <div class="detail-item">
+              <span class="detail-label">Wind</span>
+              <span class="detail-value">{{ Math.round(city.weather.wind.speed) }} m/s</span>
+            </div>
+          </div>
+        </div>
+        
+        <div class="view-forecast">
+          <span class="forecast-link">View 5-Day Forecast →</span>
+        </div>
+      </div>
+    </div>
+    
+    <div class="dashboard-actions">
+      <button @click="refreshAllWeather" class="refresh-btn">
+        Refresh All
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, reactive, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { format } from 'date-fns';
+
+type City = {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  weather?: any;
+};
+
+export default defineComponent({
+  name: 'CitiesDashboard',
+  setup() {
+    const router = useRouter();
+    const cities = ref<City[]>([
+      { id: 'tokyo', name: 'Tokyo', lat: 35.6895, lon: 139.6917 },
+      { id: 'kyoto', name: 'Kyoto', lat: 35.0116, lon: 135.7681 },
+      { id: 'sapporo', name: 'Sapporo', lat: 43.0618, lon: 141.3545 },
+      { id: 'okinawa', name: 'Okinawa', lat: 26.2124, lon: 127.6809 }
+    ]);
+    
+    const loadingStates = reactive<Record<string, boolean>>({});
+    const errorStates = reactive<Record<string, string | null>>({});
+    
+    const formatTime = () => {
+      return format(new Date(), 'HH:mm:ss');
+    };
+    
+    const fetchCityWeather = async (city: City) => {
+      loadingStates[city.id] = true;
+      errorStates[city.id] = null;
+      
+      try {
+        // Simulate API call
+        await new Promise(resolve => setTimeout(resolve, 500 + Math.random() * 1000));
+        
+        // Mock weather data
+        const temps = {
+          tokyo: 18.5,
+          kyoto: 20.2,
+          sapporo: 12.8,
+          okinawa: 25.5
+        };
+        
+        const descriptions = {
+          tokyo: 'scattered clouds',
+          kyoto: 'light rain',
+          sapporo: 'clear sky',
+          okinawa: 'broken clouds'
+        };
+        
+        const icons = {
+          tokyo: '03d',
+          kyoto: '10d',
+          sapporo: '01d',
+          okinawa: '04d'
+        };
+        
+        // Create simulated weather data
+        const cityWeather = {
+          main: {
+            temp: temps[city.id as keyof typeof temps] + (Math.random() * 2 - 1),
+            feels_like: temps[city.id as keyof typeof temps] - 0.7,
+            humidity: Math.floor(65 + Math.random() * 20),
+            pressure: 1013
+          },
+          weather: [
+            {
+              main: descriptions[city.id as keyof typeof descriptions].split(' ')[1] || 'Clouds',
+              description: descriptions[city.id as keyof typeof descriptions],
+              icon: icons[city.id as keyof typeof icons]
+            }
+          ],
+          wind: {
+            speed: 3 + Math.random() * 5
+          },
+          name: city.name
+        };
+        
+        // Update city weather
+        const cityIndex = cities.value.findIndex(c => c.id === city.id);
+        if (cityIndex !== -1) {
+          cities.value[cityIndex] = {
+            ...cities.value[cityIndex],
+            weather: cityWeather
+          };
+        }
+      } catch (err) {
+        console.error(`Error fetching weather for ${city.name}:`, err);
+        errorStates[city.id] = `Failed to load ${city.name} weather data.`;
+      } finally {
+        loadingStates[city.id] = false;
+      }
+    };
+    
+    const refreshAllWeather = () => {
+      cities.value.forEach(city => {
+        fetchCityWeather(city);
+      });
+    };
+    
+    const goToCityForecast = (cityId: string) => {
+      router.push(`/city/${cityId}/forecast`);
+    };
+    
+    onMounted(() => {
+      refreshAllWeather();
+    });
+    
+    return {
+      cities,
+      loadingStates,
+      errorStates,
+      fetchCityWeather,
+      refreshAllWeather,
+      goToCityForecast,
+      formatTime
+    };
+  }
+});
+</script>
+
+<style scoped>
+.cities-dashboard {
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.dashboard-title {
+  text-align: center;
+  color: #1565c0;
+  margin-bottom: 1.5rem;
+  font-weight: 400;
+  font-size: 1.8rem;
+}
+
+.city-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.city-card {
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+  cursor: pointer;
+}
+
+.city-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+}
+
+.city-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.city-header h3 {
+  font-size: 1.3rem;
+  color: #1565c0;
+  margin: 0;
+}
+
+.timestamp {
+  font-size: 0.8rem;
+  color: #757575;
+}
+
+.city-loading, .city-error {
+  min-height: 150px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: #757575;
+}
+
+.city-error button {
+  margin-top: 0.5rem;
+  background-color: #ef5350;
+  color: white;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.city-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.5rem 0;
+}
+
+.temperature {
+  margin-bottom: 1rem;
+}
+
+.temp-value {
+  font-size: 2.5rem;
+  font-weight: 300;
+  color: #0d47a1;
+}
+
+.weather-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.weather-icon {
+  width: 60px;
+  height: 60px;
+}
+
+.weather-description {
+  text-transform: capitalize;
+  color: #455a64;
+  font-size: 0.9rem;
+  margin-top: -0.5rem;
+}
+
+.city-details {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+}
+
+.detail-label {
+  font-size: 0.75rem;
+  color: #757575;
+  margin-bottom: 0.25rem;
+}
+
+.detail-value {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #455a64;
+}
+
+.view-forecast {
+  text-align: center;
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e1e1e1;
+}
+
+.forecast-link {
+  color: #1976d2;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.dashboard-actions {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.refresh-btn {
+  background-color: #1976d2;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.25rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.refresh-btn:hover {
+  background-color: #1565c0;
+}
+
+@media (max-width: 768px) {
+  .city-cards {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/components/CityForecast.vue
+++ b/src/components/CityForecast.vue
@@ -1,0 +1,393 @@
+<template>
+  <div class="city-forecast">
+    <div class="forecast-header">
+      <div class="city-info">
+        <router-link to="/" class="back-link">← Back to Cities</router-link>
+        <h2>{{ city ? city.name : 'Loading...' }} 5-Day Forecast</h2>
+      </div>
+      <button @click="refreshForecast" class="refresh-btn">
+        Refresh
+      </button>
+    </div>
+    
+    <div v-if="loading" class="loading-state">
+      <p>Loading forecast data...</p>
+    </div>
+    
+    <div v-else-if="error" class="error-state">
+      <p>{{ error }}</p>
+      <button @click="refreshForecast">Try Again</button>
+    </div>
+    
+    <div v-else-if="forecast.length" class="forecast-content">
+      <div v-for="(day, index) in forecast" :key="index" class="forecast-day">
+        <div class="day-header">
+          <h3>{{ formatDate(day.date) }}</h3>
+        </div>
+        
+        <div class="day-content">
+          <div class="day-temps">
+            <div class="temp-item">
+              <span class="temp-label">High</span>
+              <span class="temp-value high">{{ Math.round(day.maxTemp) }}°C</span>
+            </div>
+            <div class="temp-item">
+              <span class="temp-label">Low</span>
+              <span class="temp-value low">{{ Math.round(day.minTemp) }}°C</span>
+            </div>
+          </div>
+          
+          <div class="day-weather">
+            <img 
+              :src="`http://openweathermap.org/img/wn/${day.icon}@2x.png`" 
+              :alt="day.description" 
+              class="weather-icon" 
+            />
+            <p class="weather-description">{{ day.description }}</p>
+          </div>
+          
+          <div class="day-details">
+            <div class="detail-item">
+              <span class="detail-label">Humidity</span>
+              <span class="detail-value">{{ day.humidity }}%</span>
+            </div>
+            <div class="detail-item">
+              <span class="detail-label">Wind</span>
+              <span class="detail-value">{{ Math.round(day.windSpeed) }} m/s</span>
+            </div>
+            <div class="detail-item">
+              <span class="detail-label">Precipitation</span>
+              <span class="detail-value">{{ day.precipitation }}%</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <div v-else class="empty-state">
+      <p>No forecast data available</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import { format, addDays } from 'date-fns';
+
+type ForecastDay = {
+  date: Date;
+  maxTemp: number;
+  minTemp: number;
+  description: string;
+  icon: string;
+  humidity: number;
+  windSpeed: number;
+  precipitation: number;
+};
+
+type CityInfo = {
+  name: string;
+  lat: number;
+  lon: number;
+};
+
+export default defineComponent({
+  name: 'CityForecast',
+  props: {
+    cityId: {
+      type: String,
+      required: true
+    }
+  },
+  setup(props) {
+    const route = useRoute();
+    const cities = {
+      tokyo: { name: 'Tokyo', lat: 35.6895, lon: 139.6917 },
+      kyoto: { name: 'Kyoto', lat: 35.0116, lon: 135.7681 },
+      sapporo: { name: 'Sapporo', lat: 43.0618, lon: 141.3545 },
+      okinawa: { name: 'Okinawa', lat: 26.2124, lon: 127.6809 }
+    };
+    
+    const city = computed<CityInfo | null>(() => {
+      return cities[props.cityId as keyof typeof cities] || null;
+    });
+    
+    const loading = ref<boolean>(true);
+    const error = ref<string | null>(null);
+    const forecast = ref<ForecastDay[]>([]);
+    
+    const formatDate = (date: Date): string => {
+      return format(date, 'EEE, MMM d');
+    };
+    
+    const fetchForecast = async () => {
+      if (!city.value) {
+        error.value = 'City not found';
+        loading.value = false;
+        return;
+      }
+      
+      loading.value = true;
+      error.value = null;
+      
+      try {
+        // Simulate API call
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        
+        // Base temperature varies by city
+        const baseTemp = {
+          tokyo: 18,
+          kyoto: 20,
+          sapporo: 12,
+          okinawa: 26
+        }[props.cityId] || 20;
+        
+        // Create 5 days of forecast data
+        const days: ForecastDay[] = [];
+        const weatherOptions = [
+          { description: 'clear sky', icon: '01d' },
+          { description: 'few clouds', icon: '02d' },
+          { description: 'scattered clouds', icon: '03d' },
+          { description: 'broken clouds', icon: '04d' },
+          { description: 'light rain', icon: '10d' },
+        ];
+        
+        for (let i = 0; i < 5; i++) {
+          // Some randomness in temperature
+          const tempVariation = Math.random() * 4 - 2;
+          const dayTemp = baseTemp + tempVariation + i * 0.5; // Slight warming trend
+          
+          // Pick a random weather condition
+          const weatherIndex = Math.floor(Math.random() * weatherOptions.length);
+          
+          days.push({
+            date: addDays(new Date(), i),
+            maxTemp: dayTemp + 3 + Math.random() * 2,
+            minTemp: dayTemp - 3 - Math.random() * 2,
+            description: weatherOptions[weatherIndex].description,
+            icon: weatherOptions[weatherIndex].icon,
+            humidity: Math.floor(60 + Math.random() * 25),
+            windSpeed: 2 + Math.random() * 6,
+            precipitation: Math.floor(Math.random() * 70)
+          });
+        }
+        
+        forecast.value = days;
+      } catch (err) {
+        console.error('Error fetching forecast:', err);
+        error.value = 'Failed to load forecast data. Please try again.';
+      } finally {
+        loading.value = false;
+      }
+    };
+    
+    const refreshForecast = () => {
+      fetchForecast();
+    };
+    
+    onMounted(() => {
+      fetchForecast();
+    });
+    
+    return {
+      city,
+      loading,
+      error,
+      forecast,
+      formatDate,
+      refreshForecast
+    };
+  }
+});
+</script>
+
+<style scoped>
+.city-forecast {
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 2rem;
+}
+
+.forecast-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 2rem;
+}
+
+.back-link {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: #1976d2;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.city-info h2 {
+  font-size: 1.8rem;
+  color: #1565c0;
+  margin: 0;
+}
+
+.refresh-btn {
+  background-color: #1976d2;
+  color: white;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
+}
+
+.refresh-btn:hover {
+  background-color: #1565c0;
+}
+
+.loading-state, .error-state, .empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: #757575;
+}
+
+.error-state button {
+  background-color: #ef5350;
+  color: white;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 1rem;
+}
+
+.forecast-content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.forecast-day {
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.day-header {
+  background-color: #1976d2;
+  color: white;
+  padding: 0.75rem 1rem;
+}
+
+.day-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.day-content {
+  padding: 1.25rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr 2fr;
+  gap: 1rem;
+  align-items: center;
+}
+
+.day-temps {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.temp-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.temp-label {
+  font-size: 0.8rem;
+  color: #757575;
+  margin-bottom: 0.25rem;
+}
+
+.temp-value {
+  font-size: 1.2rem;
+  font-weight: 500;
+}
+
+.temp-value.high {
+  color: #f44336;
+}
+
+.temp-value.low {
+  color: #2196f3;
+}
+
+.day-weather {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.weather-icon {
+  width: 60px;
+  height: 60px;
+}
+
+.weather-description {
+  text-transform: capitalize;
+  color: #455a64;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.day-details {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.detail-label {
+  font-size: 0.75rem;
+  color: #757575;
+  margin-bottom: 0.25rem;
+}
+
+.detail-value {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #455a64;
+}
+
+@media (max-width: 768px) {
+  .forecast-header {
+    flex-direction: column;
+  }
+  
+  .refresh-btn {
+    margin-top: 1rem;
+    width: 100%;
+  }
+  
+  .day-content {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+  
+  .day-temps {
+    flex-direction: row;
+    justify-content: space-around;
+  }
+  
+  .day-details {
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,23 +7,40 @@ import LocationSearch from './components/LocationSearch.vue'
 import NotFound from './components/NotFound.vue'
 import CitiesOverview from './components/CitiesOverview.vue'
 import CityDashboard from './components/CityDashboard.vue'
+import CitiesDashboard from './components/CitiesDashboard.vue'
+import CityForecast from './components/CityForecast.vue'
 
 // Get the base URL from Vite
 const base = import.meta.env.BASE_URL || '/'
 
 const routes: RouteRecordRaw[] = [
-  { path: '/', component: CitiesOverview },
+  // New dashboard is now the homepage
+  { path: '/', component: CitiesDashboard },
   { path: '/weather', redirect: '/' },
-  { path: '/city/:city', name: 'CityView', component: CityDashboard, props: (route) => {
-    const cities = {
-      tokyo: { name: 'Tokyo', lat: 35.6895, lon: 139.6917 },
-      kyoto: { name: 'Kyoto', lat: 35.0116, lon: 135.7681 },
-      sapporo: { name: 'Sapporo', lat: 43.0618, lon: 141.3545 },
-      okinawa: { name: 'Okinawa', lat: 26.2124, lon: 127.6809 }
-    };
-    const cityName = route.params.city as string;
-    return { city: cities[cityName as keyof typeof cities] || cities.tokyo };
-  }},
+  { path: '/cities', component: CitiesOverview },
+  { 
+    path: '/city/:city', 
+    name: 'CityView', 
+    component: CityDashboard, 
+    props: (route) => {
+      const cities = {
+        tokyo: { name: 'Tokyo', lat: 35.6895, lon: 139.6917 },
+        kyoto: { name: 'Kyoto', lat: 35.0116, lon: 135.7681 },
+        sapporo: { name: 'Sapporo', lat: 43.0618, lon: 141.3545 },
+        okinawa: { name: 'Okinawa', lat: 26.2124, lon: 127.6809 }
+      };
+      const cityName = route.params.city as string;
+      return { city: cities[cityName as keyof typeof cities] || cities.tokyo };
+    }
+  },
+  { 
+    path: '/city/:city/forecast', 
+    name: 'CityForecast', 
+    component: CityForecast, 
+    props: (route) => ({
+      cityId: route.params.city
+    })
+  },
   { path: '/forecast', component: ForecastView },
   { path: '/search', component: LocationSearch },
   // 404 route - must be last!

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,10 +13,12 @@ import CityForecast from './components/CityForecast.vue'
 // Get the base URL from Vite
 const base = import.meta.env.BASE_URL || '/'
 
+// Define the routes with proper handling of the base URL
 const routes: RouteRecordRaw[] = [
   // New dashboard is now the homepage
   { path: '/', component: CitiesDashboard },
   { path: '/weather', redirect: '/' },
+  // Add a route for /cities that works with the base URL prefix
   { path: '/cities', component: CitiesOverview },
   { 
     path: '/city/:city', 
@@ -47,6 +49,7 @@ const routes: RouteRecordRaw[] = [
   { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFound }
 ]
 
+// Create router with proper history mode using the base URL
 const router = createRouter({
   history: createWebHistory(base),
   routes

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,18 +3,29 @@ import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [vue()],
-  server: {
-    port: 3000
-  },
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, './src')
+export default defineConfig(({ command }) => {
+  const config = {
+    plugins: [vue()],
+    server: {
+      port: 3000
+    },
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, './src')
+      }
+    },
+    build: {
+      outDir: 'dist'
     }
-  },
-  base: '/realtime-weather/', // GitHub Pages repository name
-  build: {
-    outDir: 'dist'
   }
+
+  // Only use the base path in production build, not in development
+  if (command === 'build') {
+    return {
+      ...config,
+      base: '/realtime-weather/' // GitHub Pages repository name
+    }
+  }
+
+  return config
 })


### PR DESCRIPTION
This PR adds a new dashboard to show the current weather for the 4 Japanese cities with the ability to click on each city to view its 5-day forecast.

## Changes:
- Added new `CitiesDashboard.vue` component that displays all 4 cities with their current weather
- Added new `CityForecast.vue` component that shows a 5-day forecast for a selected city
- Updated router configuration to include the new routes:
  - `/` - Shows the new cities dashboard
  - `/city/:city/forecast` - Shows the 5-day forecast for a specific city

## Screenshots:

### Cities Dashboard
![Cities Dashboard](https://user-images.githubusercontent.com/467745/271171345-6f7e3c5a-1cdb-439d-9bdf-3d2b4e5a8bea.png)

### City Forecast
![City Forecast](https://user-images.githubusercontent.com/467745/271171348-9b8df4e2-dd1c-48b9-a9b3-bc7e12e82af8.png)