### PR TITLE
Fix weather icons to use HTTPS instead of HTTP

### DIFF
--- a/src/components/CitiesDashboard.vue
+++ b/src/components/CitiesDashboard.vue
@@ -24,7 +24,7 @@
           </div>
           <div class="weather-info">
             <img 
-              :src="`http://openweathermap.org/img/wn/${city.weather.weather[0].icon}@2x.png`" 
+              :src="`https://openweathermap.org/img/wn/${city.weather.weather[0].icon}@2x.png`" 
               :alt="city.weather.weather[0].description" 
               class="weather-icon" 
             />

--- a/src/components/CityForecast.vue
+++ b/src/components/CityForecast.vue
@@ -39,7 +39,7 @@
           
           <div class="day-weather">
             <img 
-              :src="`http://openweathermap.org/img/wn/${day.icon}@2x.png`" 
+              :src="`https://openweathermap.org/img/wn/${day.icon}@2x.png`" 
               :alt="day.description" 
               class="weather-icon" 
             />


### PR DESCRIPTION
This PR fixes the mixed content issues that were causing the weather dashboards to not display correctly.

## Changes:
- Changed all weather icon URLs from HTTP to HTTPS in both `CitiesDashboard.vue` and `CityForecast.vue`
- The application will now work properly in both HTTP and HTTPS environments

## Before:
The weather icons didn't load due to mixed content blocking (HTTP content in HTTPS pages)

## After:
All weather icons load correctly because they're served over HTTPS

This is an important security fix as browsers block mixed content by default.